### PR TITLE
Rebuild images on deploy

### DIFF
--- a/salt/microsimulation-demo/init.sls
+++ b/salt/microsimulation-demo/init.sls
@@ -25,7 +25,7 @@ microsimulation-demo-configuration:
         - require:
             - microsimulation-demo-repository
 
-microsimulation-demo-docker-compose:
+microsimulation-demo-docker-compose-build:
     cmd.run:
         - name: |
             docker-compose -f docker-compose.yml up -d --force-recreate
@@ -34,6 +34,15 @@ microsimulation-demo-docker-compose:
         - require:
             - microsimulation-demo-configuration
 
+microsimulation-demo-docker-compose-up:
+    cmd.run:
+        - name: |
+            docker-compose -f docker-compose.yml up -d --force-recreate
+        - cwd: /srv/microsimulation-demo
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - microsimulation-demo-docker-compose-build
+
 microsimulation-demo-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/microsimulation-demo.conf
@@ -41,7 +50,7 @@ microsimulation-demo-nginx-vhost:
         - template: jinja
         - require:
             - nginx-config
-            - microsimulation-demo-docker-compose
+            - microsimulation-demo-docker-compose-up
         - listen_in:
             - service: nginx-server-service
 

--- a/salt/microsimulation-demo/init.sls
+++ b/salt/microsimulation-demo/init.sls
@@ -37,7 +37,7 @@ microsimulation-demo-docker-compose-build:
 microsimulation-demo-docker-compose-up:
     cmd.run:
         - name: |
-            docker-compose -f docker-compose.yml up -d --force-recreate
+            docker-compose -f docker-compose.yml build
         - cwd: /srv/microsimulation-demo
         - user: {{ pillar.elife.deploy_user.username }}
         - require:

--- a/salt/microsimulation-demo/init.sls
+++ b/salt/microsimulation-demo/init.sls
@@ -27,8 +27,7 @@ microsimulation-demo-configuration:
 
 microsimulation-demo-docker-compose-build:
     cmd.run:
-        - name: |
-            docker-compose -f docker-compose.yml up -d --force-recreate
+        - name: docker-compose -f docker-compose.yml build
         - cwd: /srv/microsimulation-demo
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
@@ -36,8 +35,7 @@ microsimulation-demo-docker-compose-build:
 
 microsimulation-demo-docker-compose-up:
     cmd.run:
-        - name: |
-            docker-compose -f docker-compose.yml build
+        - name: docker-compose -f docker-compose.yml up -d --force-recreate
         - cwd: /srv/microsimulation-demo
         - user: {{ pillar.elife.deploy_user.username }}
         - require:


### PR DESCRIPTION
To fix https://github.com/elifesciences/issues/issues/4915

Since this deploy is source-based, once the repository is updated we need to rebuild the image before we start a new container. We don't usually have this problem because we publish images with a tag, and the tag is changed and pulled on every deploy.